### PR TITLE
Removal of master and slave words

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -52,7 +52,7 @@ def commit_and_sync(comment=None):
     """git commit and sync"""
     output_list = local('git status', True).split('\n')
     branch = output_list[0].replace('On branch ', '')
-    if branch in ['develop', 'master']:
+    if branch in ['develop', 'main']:
         puts('不允许在 {} 分支 用 {} 命令直接操作'.format(yellow(branch), get_function_name()))
     elif 'nothing to commit' in output_list[-1]:
         puts('{} 分支没有变动, 不需要提交'.format(yellow(branch)))
@@ -78,7 +78,7 @@ def update_from_develop():
     """从 develop 更新到当前分支"""
     output_list = local('git status', True).split('\n')
     branch = output_list[0].replace('On branch ', '')
-    if branch in ['develop', 'master']:
+    if branch in ['develop', 'main']:
         puts('不允许在 {} 分支 用 {} 命令直接操作'.format(yellow(branch), get_function_name()))
     elif 'nothing to commit' in output_list[-1]:
         local_proxy('git pull origin develop')
@@ -92,7 +92,7 @@ def update_to_develop():
     """从当前分支更新到 develop """
     output_list = local('git status', True).split('\n')
     branch = output_list[0].replace('On branch ', '')
-    if branch in ['develop', 'master']:
+    if branch in ['develop', 'main']:
         puts('不允许在 {} 分支 用 {} 命令直接操作'.format(yellow(branch), get_function_name()))
     elif 'nothing to commit' in output_list[-1]:
         confirm = raw_input('是否已经update_from_develop? [y/N]: '.format(yellow(branch)))

--- a/railguns/django/db/models.py
+++ b/railguns/django/db/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-from .utils import generate_shard_id, get_user_id, db_master
+from .utils import generate_shard_id, get_user_id, db_main
 
 
 class DateTimeModelMixin(models.Model):
@@ -47,7 +47,7 @@ class ShardModel(OwnerModel):
         self.full_clean()
         if self.pk is None:
             self.pk = generate_shard_id(self.user_id)
-        super(ShardModel, self).save(using=db_master(self.user_id), *args, **kwargs)
+        super(ShardModel, self).save(using=db_main(self.user_id), *args, **kwargs)
 
 
 class ShardLCModel(OwnerModel):
@@ -61,8 +61,8 @@ class ShardLCModel(OwnerModel):
         self.full_clean()
         if self.pk is None:  # Create
             self.pk = generate_shard_id(self.user_id)
-        super(ShardLCModel, self).save(using=db_master(self.user_id), *args, **kwargs)  # 保存第一份.
+        super(ShardLCModel, self).save(using=db_main(self.user_id), *args, **kwargs)  # 保存第一份.
         card_user_id = get_user_id(self.card_id)
-        if db_master(card_user_id) != db_master(self.user_id):  # 保存第二份.
+        if db_main(card_user_id) != db_main(self.user_id):  # 保存第二份.
             self.is_origin = False
-            super(ShardLCModel, self).save(using=db_master(card_user_id), *args, **kwargs)
+            super(ShardLCModel, self).save(using=db_main(card_user_id), *args, **kwargs)

--- a/railguns/django/db/utils.py
+++ b/railguns/django/db/utils.py
@@ -35,7 +35,7 @@ def get_user_id(pk):
     return pk & 0xFFFFFFFF
 
 
-def db_master(user_id=None):
+def db_main(user_id=None):
     """
     需要保证传入的user_id都是int
     """
@@ -48,12 +48,12 @@ def db_master(user_id=None):
             return 'db_{}'.format(user_id % settings.SHARD_COUNT)
 
 
-def db_slave(user_id=None):
+def db_subordinate(user_id=None):
     suffix = ''
-    return '{}{}'.format(db_master(user_id), suffix)  # replica_
+    return '{}{}'.format(db_main(user_id), suffix)  # replica_
 
 
-def redis_master(user_id=None):
+def redis_main(user_id=None):
     if not user_id:
         return 0
     else:


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.